### PR TITLE
separate build profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,26 @@ language: cpp
 
 env:
   matrix:
-  - JOB_ARCH=amd64
-  - JOB_ARCH=arm64
-  - JOB_ARCH=armel
-  - JOB_ARCH=armhf
-  - JOB_ARCH=i386
-  - JOB_ARCH=mips
-  - JOB_ARCH=mips64el
-  - JOB_ARCH=mipsel
-  - JOB_ARCH=ppc64el
-  - JOB_ARCH=s390x
+  - JOB_STAGE=1 JOB_ARCH=amd64
+  - JOB_STAGE=1 JOB_ARCH=arm64
+  - JOB_STAGE=1 JOB_ARCH=armel
+  - JOB_STAGE=1 JOB_ARCH=armhf
+  - JOB_STAGE=1 JOB_ARCH=i386
+  - JOB_STAGE=1 JOB_ARCH=mips
+  - JOB_STAGE=1 JOB_ARCH=mips64el
+  - JOB_STAGE=1 JOB_ARCH=mipsel
+  - JOB_STAGE=1 JOB_ARCH=ppc64el
+  - JOB_STAGE=1 JOB_ARCH=s390x
+  - JOB_STAGE=2 JOB_ARCH=amd64
+  - JOB_STAGE=2 JOB_ARCH=arm64
+  - JOB_STAGE=2 JOB_ARCH=armel
+  - JOB_STAGE=2 JOB_ARCH=armhf
+  - JOB_STAGE=2 JOB_ARCH=i386
+  - JOB_STAGE=2 JOB_ARCH=mips
+  - JOB_STAGE=2 JOB_ARCH=mips64el
+  - JOB_STAGE=2 JOB_ARCH=mipsel
+  - JOB_STAGE=2 JOB_ARCH=ppc64el
+  - JOB_STAGE=2 JOB_ARCH=s390x
   global:
   - DOCKER_EXEC_ROOT="sudo docker exec --interactive --tty --user root test_container"
   - DOCKER_EXEC="sudo docker exec --interactive --tty test_container"
@@ -55,6 +65,7 @@ install:
 - ${DOCKER_EXEC_ROOT} apt-get update -qq
 - |
   ${DOCKER_EXEC_ROOT} \
+    env "DEB_BUILD_PROFILES=pkg.$(cat debian/control | grep ^Source: | awk '{print $2}').stage${JOB_STAGE}" \
     mk-build-deps --install --remove \
       --host-arch ${JOB_ARCH} \
       --root-cmd sudo \
@@ -66,6 +77,7 @@ script:
       "DEB_BUILD_OPTIONS=nocheck" \
     dpkg-buildpackage \
       --host-arch ${JOB_ARCH} \
+      --build-profiles=pkg.$(cat debian/control | grep ^Source: | awk '{print $2}').stage${JOB_STAGE},nocheck \
       -i -us -uc -b;
 - ${DOCKER_EXEC} make -C debian/build -j $(nproc) .gitignore distcheck
 - git status

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,10 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--build=$(build_alias) \
 	--disable-dependency-tracking \
 	--disable-maintainer-mode
+if WITH_STAGE_2
+DISTCHECK_CONFIGURE_FLAGS += \
+	--with-stage=2
+endif
 
 GITIGNOREFILES = \
 	debian \
@@ -57,6 +61,9 @@ check_LTLIBRARIES =
 
 include $(srcdir)/gtest.mk
 include $(srcdir)/include/Makefile.inc
+
+
+if WITH_STAGE_1
 pkgconfig_DATA += \
     android-frameworks-native-$(LAARID_API_VERSION).pc
 # ---------------------
@@ -77,8 +84,14 @@ include $(srcdir)/libs/ui/Android.mk
 include $(srcdir)/services/batteryservice/Android.mk
 include $(srcdir)/services/powermanager/Android.mk
 # ---------------------
-include $(srcdir)/libs/gui/Android.mk
 include $(srcdir)/services/inputflinger/Android.mk
+else
+if WITH_STAGE_2
+include $(srcdir)/opengl/libs/Android.mk
+# ---------------------
+include $(srcdir)/libs/gui/Android.mk
+endif
+endif
 
 # PKG-CONFIG data files
 # ---------------------

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,20 @@ AC_SUBST([LT_VERSION_INFO])
 
 LT_OUTPUT
 
+# Build stages
+# ------------
+# Android source code might have circular dependency between two or more
+# source repositories, so spliting them into some stages is necessary. Here
+# we have currently stage 1 and 2 only.
+AC_ARG_WITH([stage],
+  [AS_HELP_STRING([--with-stage], [Stage to build with @<:@default=1@:>@])],
+  [AS_CASE([${with_stage}],
+    [1|2], [AC_MSG_RESULT([Building for stage ${with_stage}])],
+    [AC_MSG_ERROR([Unknown stage "${with_stage}"])])],
+  [with_stage=1])
+AM_CONDITIONAL([WITH_STAGE_1], [test "x${with_stage}" = x1])
+AM_CONDITIONAL([WITH_STAGE_2], [test "x${with_stage}" = x2])
+
 dnl Thread implementation
 dnl ---------------------
 AX_PTHREAD(
@@ -131,36 +145,55 @@ AC_SUBST([HARDWARE_API_VERSION])
 AC_SUBST([HARDWARE_REQUIRED_VERSION])
 PKG_CHECK_MODULES([HARDWARE], [android-hardware-$HARDWARE_API_VERSION >= $HARDWARE_REQUIRED_VERSION])
 
-HARDWARE_LEGACY_API_VERSION=0.0
-HARDWARE_LEGACY_REQUIRED_VERSION=0.0.2
-AC_SUBST([HARDWARE_LEGACY_API_VERSION])
-AC_SUBST([HARDWARE_LEGACY_REQUIRED_VERSION])
-PKG_CHECK_MODULES([HARDWARE_LEGACY], [android-hardware-legacy-$HARDWARE_LEGACY_API_VERSION >= $HARDWARE_LEGACY_REQUIRED_VERSION])
+AM_COND_IF([WITH_STAGE_1],
+  [HARDWARE_LEGACY_API_VERSION=0.0
+  HARDWARE_LEGACY_REQUIRED_VERSION=0.0.2
+  AC_SUBST([HARDWARE_LEGACY_API_VERSION])
+  AC_SUBST([HARDWARE_LEGACY_REQUIRED_VERSION])
+  PKG_CHECK_MODULES([HARDWARE_LEGACY], [android-hardware-legacy-$HARDWARE_LEGACY_API_VERSION >= $HARDWARE_LEGACY_REQUIRED_VERSION])
 
-PKG_CHECK_MODULES([EGL], [egl])
-PKG_CHECK_MODULES([GLESV1_CM], [glesv1_cm])
-PKG_CHECK_MODULES([GLESV2], [glesv2])
-PKG_CHECK_MODULES([ZLIB], [zlib])
-PKG_CHECK_MODULES([CRYPTO], [libcrypto])
-PKG_CHECK_MODULES([SELINUX], [libselinux])
+  PKG_CHECK_MODULES([CRYPTO], [libcrypto])
+  PKG_CHECK_MODULES([SELINUX], [libselinux])
+  PKG_CHECK_MODULES([ZLIB], [zlib])]
+)
+
+AM_COND_IF([WITH_STAGE_2],
+  [PKG_CHECK_MODULES([BINDER], [android-binder-$LAARID_API_VERSION])
+  PKG_CHECK_MODULES([UI], [android-ui-$LAARID_API_VERSION])
+  PKG_CHECK_MODULES([EGL], [egl])
+  PKG_CHECK_MODULES([GLESV1_CM], [glesv1_cm])
+  PKG_CHECK_MODULES([GLESV2], [glesv2])]
+)
 
 dnl Extra Features
 dnl --------------
 
-AC_ARG_WITH([64bit-binder],
-  [AS_HELP_STRING([--with-64bit-binder],
-    [Use 64-bit binder IPC. Default no on 32-bit platforms, yes otherwise.])],
-  [], [])
-AS_IF([test "x${with_64bit_binder}" = "x" ],
-  [AC_TRY_COMPILE([
+AM_COND_IF([WITH_STAGE_1],
+  [AC_ARG_WITH([64bit-binder],
+    [AS_HELP_STRING([--with-64bit-binder],
+      [Use 64-bit binder IPC. Default no on 32-bit platforms, yes otherwise.])],
+    [], [])
+  AS_IF([test "x${with_64bit_binder}" = "x"],
+    [AC_TRY_COMPILE([
 #if !defined(__LP64__)
 #error "Not 64 bit systems"
 #endif
-], [], [with_64bit_binder=yes], [with_64bit_binder=no])])
-AM_CONDITIONAL([WITH_64BIT_BINDER], [test "x${with_64bit_binder}" = "xyes"])
+      ], [], [with_64bit_binder=yes], [with_64bit_binder=no])
+    ])
+  dnl Whether should we run binder driver tests
+  AS_IF([test "x${cross_compiling}" != xyes],
+    [AC_CHECK_FILE([/dev/binder])])
+  ]
+) dnl WITH_STAGE_1
 
-AC_ARG_ENABLE([fence-sync],
-  [AS_HELP_STRING([--enable-fence-sync], [Use fence sync])], [], [])
+AM_CONDITIONAL([WITH_64BIT_BINDER], [test "x${with_64bit_binder}" = "xyes"])
+AM_CONDITIONAL([HAVE_DEV_BINDER], [test "x${c_cv_file_dev_binder}" = xyes])
+
+AM_COND_IF([WITH_STAGE_2],
+  [AC_ARG_ENABLE([fence-sync],
+    [AS_HELP_STRING([--enable-fence-sync], [Use fence sync])])]
+) dnl WITH_STAGE_2
+
 AM_CONDITIONAL([ENABLE_FENCE_SYNC], [test "x${enable_fence_sync}" != "xno"])
 
 # GTest
@@ -190,27 +223,30 @@ AC_SUBST([GTEST_SRCDIR])
 AC_LANG_POP()
 AM_CONDITIONAL([HAVE_GTEST], [test "x${with_gtest}" != xno])
 
-dnl Whether should we run binder driver tests
-AS_IF([test "x${cross_compiling}" != xyes],
-  [AC_CHECK_FILE([/dev/binder])])
-AM_CONDITIONAL([HAVE_DEV_BINDER], [test "x${c_cv_file_dev_binder}" = xyes])
-
 dnl Output Files
 dnl ------------
 AC_CONFIG_FILES([
   Makefile
-  android-frameworks-native-$LAARID_API_VERSION.pc
-  libs/binder/android-binder-$LAARID_API_VERSION.pc
-  libs/diskusage/android-diskusage-$LAARID_API_VERSION.pc
-  libs/gui/android-gui-$LAARID_API_VERSION.pc
-  libs/input/android-input-$LAARID_API_VERSION.pc
-  libs/ui/android-ui-$LAARID_API_VERSION.pc
-  opengl/libs/EGL/android-egl-$LAARID_API_VERSION.pc
-  opengl/libs/ETC1/android-etc1-$LAARID_API_VERSION.pc
-  opengl/libs/GLES2/android-glesv2-$LAARID_API_VERSION.pc
-  opengl/libs/GLES_CM/android-glesv1_cm-$LAARID_API_VERSION.pc
-  services/batteryservice/android-batteryservice-$LAARID_API_VERSION.pc
-  services/inputflinger/android-inputflinger-$LAARID_API_VERSION.pc
-  services/powermanager/android-powermanager-$LAARID_API_VERSION.pc
 ])
+AM_COND_IF([WITH_STAGE_1],
+  [AC_CONFIG_FILES(
+    [android-frameworks-native-$LAARID_API_VERSION.pc
+    libs/binder/android-binder-$LAARID_API_VERSION.pc
+    libs/diskusage/android-diskusage-$LAARID_API_VERSION.pc
+    libs/input/android-input-$LAARID_API_VERSION.pc
+    libs/ui/android-ui-$LAARID_API_VERSION.pc
+    opengl/libs/ETC1/android-etc1-$LAARID_API_VERSION.pc
+    services/batteryservice/android-batteryservice-$LAARID_API_VERSION.pc
+    services/inputflinger/android-inputflinger-$LAARID_API_VERSION.pc
+    services/powermanager/android-powermanager-$LAARID_API_VERSION.pc]
+  )]
+)
+AM_COND_IF([WITH_STAGE_2],
+  [AC_CONFIG_FILES(
+    [libs/gui/android-gui-$LAARID_API_VERSION.pc
+    opengl/libs/EGL/android-egl-$LAARID_API_VERSION.pc
+    opengl/libs/GLES2/android-glesv2-$LAARID_API_VERSION.pc
+    opengl/libs/GLES_CM/android-glesv1_cm-$LAARID_API_VERSION.pc]
+  )]
+)
 AC_OUTPUT

--- a/debian/control
+++ b/debian/control
@@ -6,24 +6,27 @@ Build-Depends:
  dh-autoreconf,
  autoconf-archive,
  pkg-config (>= 0.24),
+ android-frameworks-native-headers <pkg.android-frameworks-native.stage2>,
  libandroid-backtrace0-dev (>= 0.0.19) [amd64 i386 arm64 armel armhf mips mips64el mipsel ppc64el],
  libandroid-base0-dev (>= 0.0.19),
+ libandroid-binder0-dev <pkg.android-frameworks-native.stage2>,
  libandroid-bionic0-dev (>= 0.1.4),
  libandroid-cutils0-dev (>= 0.0.19),
  libandroid-hardware0-dev (>= 0.0.1+b1),
- libandroid-hardware-legacy0-dev (>= 0.0.2),
+ libandroid-hardware-legacy0-dev (>= 0.0.2) <!pkg.android-frameworks-native.stage2>,
  libandroid-log0-dev (>= 0.0.19),
  libandroid-nativehelper0-dev (>= 0.0.4),
  libandroid-sync0-dev (>= 0.0.19),
+ libandroid-ui0-dev <pkg.android-frameworks-native.stage2>,
  libandroid-uidmap0-dev (>= 0.0.19),
  libandroid-utils0-dev (>= 0.0.19),
- libegl1-mesa-dev,
- libgles1-mesa-dev,
- libgles2-mesa-dev,
+ libegl1-mesa-dev <pkg.android-frameworks-native.stage2>,
+ libgles1-mesa-dev <pkg.android-frameworks-native.stage2>,
+ libgles2-mesa-dev <pkg.android-frameworks-native.stage2>,
  libgtest-dev,
- libselinux1-dev,
- libssl-dev,
- zlib1g-dev,
+ libselinux1-dev <!pkg.android-frameworks-native.stage2>,
+ libssl-dev <!pkg.android-frameworks-native.stage2>,
+ zlib1g-dev <!pkg.android-frameworks-native.stage2>,
 Standards-Version: 3.9.5
 Section: libs
 Homepage: https://github.com/laarid/package_android-frameworks-native
@@ -31,6 +34,7 @@ Vcs-Git: https://github.com/laarid/package_android-frameworks-native.git
 Vcs-Browser: https://github.com/laarid/package_android-frameworks-native
 
 Package: android-frameworks-native-bin
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: misc
 Architecture: any
@@ -42,6 +46,7 @@ Description: Android native frameworks - utilities
  This package contains utilities built from Android platform/frameworks/native.
 
 Package: android-frameworks-native-headers
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: misc
 Architecture: any
@@ -56,6 +61,7 @@ Description: Android native framework headers
  not belong to any local module.
 
 Package: android-servicemanager
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: misc
 Architecture: any
@@ -70,6 +76,7 @@ Description: Android native frameworks - service manager
  platform/frameworks/native.
 
 Package: libandroid-batteryservice0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -87,6 +94,7 @@ Description: Android libbatteryservice - development
  This package contains the development files.
 
 Package: libandroid-batteryservice0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -100,6 +108,7 @@ Description: Android libbatteryservice
  platform/frameworks/native.
 
 Package: libandroid-binder0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -118,6 +127,7 @@ Description: Android libbinder - development
  This package contains the development files.
 
 Package: libandroid-binder0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -130,6 +140,7 @@ Description: Android libbinder
  This package contains libbinder built from Android platform/frameworks/native.
 
 Package: libandroid-diskusage0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -144,6 +155,7 @@ Description: Android libdiskusage - development
  This package contains the development files.
 
 Package: libandroid-diskusage0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -157,6 +169,7 @@ Description: Android libdiskusage
  platform/frameworks/native.
 
 Package: libandroid-egl0-dev
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -171,6 +184,7 @@ Description: Android libEGL - development
  This package contains the development files.
 
 Package: libandroid-egl0
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -183,6 +197,7 @@ Description: Android libEGL
  This package contains libEGL built from Android platform/frameworks/native.
 
 Package: libandroid-etc1-0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -196,6 +211,7 @@ Description: Android libETC1 - development
  This package contains the development files.
 
 Package: libandroid-etc1-0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -208,6 +224,7 @@ Description: Android libETC1
  This package contains libETC1 built from Android platform/frameworks/native.
 
 Package: libandroid-glesv1-cm0-dev
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -223,6 +240,7 @@ Description: Android libGLESv1_CM - development
  This package contains the development files.
 
 Package: libandroid-glesv1-cm0
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -236,6 +254,7 @@ Description: Android libGLESv1_CM
  platform/frameworks/native.
 
 Package: libandroid-glesv2-0-dev
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -250,6 +269,7 @@ Description: Android libGLESv2 - development
  This package contains the development files.
 
 Package: libandroid-glesv2-0
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -262,6 +282,7 @@ Description: Android libGLESv2
  This package contains libGLESv2 built from Android platform/frameworks/native.
 
 Package: libandroid-gui0-dev
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -277,6 +298,7 @@ Description: Android libgui - development
  This package contains the development files.
 
 Package: libandroid-gui0
+Build-Profiles: <pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -289,6 +311,7 @@ Description: Android libgui
  This package contains libgui built from Android platform/frameworks/native.
 
 Package: libandroid-input0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -306,6 +329,7 @@ Description: Android libinput - development
  This package contains the development files.
 
 Package: libandroid-input0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -318,6 +342,7 @@ Description: Android libinput
  This package contains libinput built from Android platform/frameworks/native.
 
 Package: libandroid-inputflinger0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -337,6 +362,7 @@ Description: Android libinputflinger - development
  This package contains the development files.
 
 Package: libandroid-inputflinger0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -350,6 +376,7 @@ Description: Android libinputflinger
  platform/frameworks/native.
 
 Package: libandroid-powermanager0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -367,6 +394,7 @@ Description: Android libpowermanager - development
  This package contains the development files.
 
 Package: libandroid-powermanager0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any
@@ -380,6 +408,7 @@ Description: Android libpowermanager
  platform/frameworks/native.
 
 Package: libandroid-ui0-dev
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libdevel
 Architecture: any
@@ -399,6 +428,7 @@ Description: Android libui - development
  This package contains the development files.
 
 Package: libandroid-ui0
+Build-Profiles: <!pkg.android-frameworks-native.stage2>
 Priority: extra
 Section: libs
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,9 @@ CONFFLAGS =
 ifneq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 CONFFLAGS += --without-gtest
 endif
+ifneq ($(filter pkg.android-frameworks-native.stage2,$(DEB_BUILD_PROFILES)),)
+CONFFLAGS += --with-stage=2
+endif
 
 # main packaging script based on dh7 syntax
 %:
@@ -20,5 +23,7 @@ endif
 override_dh_auto_configure:
 	dh_auto_configure -- $(CONFFLAGS)
 
+ifeq ($(filter pkg.android-frameworks-native.stage2,$(DEB_BUILD_PROFILES)),)
 override_dh_installinit:
 	dh_systemd_enable -pandroid-servicemanager --name=servicemanager
+endif

--- a/libs/gui/Android.mk
+++ b/libs/gui/Android.mk
@@ -26,6 +26,8 @@ lib_LTLIBRARIES += \
 	$(NATIVEHELPER_CFLAGS) \
 	$(UIDMAP_CFLAGS) \
 	$(UTILS_CFLAGS) \
+	$(BINDER_CFLAGS) \
+	$(UI_CFLAGS) \
 	-DANDROID_EGL_PLATFORM
 #	-DDEBUG_ONLY_CODE=1
 
@@ -78,8 +80,8 @@ lib_LTLIBRARIES += \
 	$(CUTILS_LIBS) \
 	$(UIDMAP_LIBS) \
 	$(UTILS_LIBS) \
-	libs/binder/libandroid-binder.la \
-	libs/ui/libandroid-ui.la \
+	$(BINDER_LIBS) \
+	$(UI_LIBS) \
 	opengl/libs/EGL/libandroid-EGL.la \
 	opengl/libs/GLES2/libandroid-GLESv2.la
 

--- a/libs/gui/tests/Android.mk
+++ b/libs/gui/tests/Android.mk
@@ -62,8 +62,8 @@ check_PROGRAMS += \
     $(SYNC_LIBS) \
     $(UTILS_LIBS) \
     $(GTEST_LIBS) \
-    libs/binder/libandroid-binder.la \
-    libs/ui/libandroid-ui.la \
+    $(BINDER_LIBS) \
+    $(UI_LIBS) \
     libs/gui/libandroid-gui.la
 
 %canon_reldir%_libgui_test_DEPENDENCIES = \

--- a/opengl/libs/Android.mk
+++ b/opengl/libs/Android.mk
@@ -1,3 +1,4 @@
+if WITH_STAGE_2
 lib_LTLIBRARIES += \
 	%reldir%/EGL/libandroid-EGL.la
 
@@ -59,6 +60,9 @@ lib_LTLIBRARIES += \
 pkgconfig_DATA += \
     %reldir%/GLES2/android-glesv2-$(LAARID_API_VERSION).pc
 
+else
+if WITH_STAGE_1
+
 ###############################################################################
 # Build the ETC1 device library
 #
@@ -82,5 +86,8 @@ lib_LTLIBRARIES += \
 
 pkgconfig_DATA += \
     %reldir%/ETC1/android-etc1-$(LAARID_API_VERSION).pc
+
+endif # WITH_STAGE_1
+endif # !WITH_STAGE_2
 
 #include $(call all-makefiles-under,$(LOCAL_PATH))


### PR DESCRIPTION
MESA development packages should depends on platform specific headers,
and for the android platform, it's android-frameworks-native-headers
binary package built from this source package. That follows all the
binary packages depending on MESA packages will create an dependency
loop and block bootstrapping. So, as what I've done to
android-system-core, this source package will be divided into two build
profiles:

  - pkg.android-frameworks-native.stage1 (default)
  - pkg.android-frameworks-native.stage2

For stage2, we have so far OpenGL depending packages only but not
limited to.